### PR TITLE
Heading styles

### DIFF
--- a/less/uams.accessibility.less
+++ b/less/uams.accessibility.less
@@ -12,7 +12,7 @@ a.screen-reader-shortcut {
         &:focus {
             z-index: 999;
             font-size: 14px;
-            font-weight: @bold;
+            font-weight: @extrabold;
             top: 6px;
             padding: 15px 23px 14px;
             background-color: @100grey;

--- a/less/uams.accordion.less
+++ b/less/uams.accordion.less
@@ -6,7 +6,7 @@
 
 
 .uams-accordion {
-    h3 {
+    h3, .h3 {
         background-color: @300grey;
         color: @800grey;
         padding: 15px 15px 15px 15px;
@@ -18,14 +18,14 @@
         &.active:after {
             background-position: -383px -23px;
         }
-    }
-    h3:after {
-        content: " ";
-        float: right;
-        display: block;
-        width: 30px;
-        height: 25px;
-        background: url(assets/svg/uams-sprite.svg) no-repeat -383px 2px rgba(255, 255, 255, 0);
+        &:after {
+            content: " ";
+            float: right;
+            display: block;
+            width: 30px;
+            height: 25px;
+            background: url(assets/svg/uams-sprite.svg) no-repeat -383px 2px rgba(255, 255, 255, 0);
+        }
     }
     div {
         height: 0px;

--- a/less/uams.alert.less
+++ b/less/uams.alert.less
@@ -2,7 +2,7 @@
   padding: 0 20px 40px;
   position: relative;
   z-index: 1;
-  h1 {
+  h1, .h1 {
     color: white;
     font-size: 25px;
   }

--- a/less/uams.blogroll.less
+++ b/less/uams.blogroll.less
@@ -52,7 +52,7 @@
             overflow: hidden;
         }
         span.date {
-            font-weight: @extrabold;
+            font-weight: @body;
             margin: 10px 0 0;
             font-size: @font-size-h5;
             font-family: @font-family-headline;

--- a/less/uams.blogroll.less
+++ b/less/uams.blogroll.less
@@ -52,7 +52,7 @@
             overflow: hidden;
         }
         span.date {
-            font-weight: @bold;
+            font-weight: @extrabold;
             margin: 10px 0 0;
             font-size: @font-size-h5;
             font-family: @font-family-headline;
@@ -103,7 +103,7 @@
     //&.mini {
     //    h2, .h2 {
     //        font-size: 18px;
-    //        font-weight: @bold;
+    //        font-weight: @extrabold;
     //        line-height: 1.4;
     //        margin: 10px 0 10px;
     //    }

--- a/less/uams.blogroll.less
+++ b/less/uams.blogroll.less
@@ -88,7 +88,7 @@
             }
         }
     }
-    h2 {
+    h2, .h2{
         margin: 20px 0 0px;
     }
 
@@ -101,7 +101,7 @@
 
 
     //&.mini {
-    //    h2 {
+    //    h2, .h2 {
     //        font-size: 18px;
     //        font-weight: @bold;
     //        line-height: 1.4;

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -36,7 +36,7 @@ small,
 .lead {
 	font-family: @font-family-headline;
 	font-size: 23px;
-	font-weight: 400;
+	font-weight: @regular;
 	line-height: 1.5;
 	margin-bottom: 20px;
 }
@@ -238,7 +238,7 @@ span.next-page {
 	a {
 		text-decoration: none;
 		border-bottom: 1px dotted @link;
-		//font-weight: 400;
+		//font-weight: @regular;
 	}
 
 	p a:visited {

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -4,9 +4,11 @@ ul {
 	padding-left: 25px;
 	//list-style-position: inside;
 }
+
 dt {
 	font-weight: @heading;
 }
+
 dd {
 	margin-bottom: 24.5px;
 }
@@ -30,7 +32,6 @@ small,
 	line-height: 1.5;
 }
 
-
 .intro,
 .lead {
 	font-family: @font-family-headline;
@@ -47,8 +48,9 @@ small,
 
 a.more {
   position: relative;
-  border-bottom: 1px dotted @link;
- // display: inline-block;
+	border-bottom: 1px dotted @link;
+	// display: inline-block;
+
   &:after {
     background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -206px -492px;
     content: "";
@@ -66,6 +68,7 @@ a.more {
 
 .uams-body {
 	position:relative;
+
 	&.container {
 		background-color: white;
 		margin-bottom: 80px;
@@ -87,21 +90,26 @@ a.more {
 	h6, .h6 {
 		letter-spacing: normal;
 	}
+
 	h1, .h1 {
 		font-weight: @extrabold;
 	}
+
 	h1, .h1,
 	h2, .h2 {
 		color: @red;
 		display: block;
 	}
+
 	blockquote {
 		border-left: 3px solid @300grey;
+
 		p {
 			font-family: @font-family-headline;
 			font-size: floor(@font-size-base * 1.111);
 		}
 	}
+
 	.uams-site-title {
 		position: absolute;
 		top: -150px;
@@ -112,42 +120,52 @@ a.more {
 		line-height: 55px;
 		font-weight: @heavy;
 		-webkit-font-smoothing: antialiased;
+
 		span {
 			font-weight: @extrabold;
 		}
 	}
+
 	a.uams-site-title {
 		color: #fff;
+
 		&:focus, &:hover {
 			color:#fff;
 			border-bottom: none;
 			text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.5);
 		}
 	}
+
 	div.uams-site-title {
 		margin-top: 29px;
 		margin-bottom: 14.5px;
 	}
+
   p.date {
     margin-top: 25px;
-    margin-bottom: -19px;
+		margin-bottom: -19px;
+		
     // &:first-of-type{
     //     margin-top: 0px;
     // }
-  }
+	}
+	
   .author-info {
     margin: -4.5px 0 20px 0;
     font-weight: @heavy;
     display: inline-block;
-  }
+	}
+	
   .category-info {
     display: inline-block;
-    margin-left: 3px;
+		margin-left: 3px;
+		
     .category-list {
     	padding-left: 8px;
     	border-left: 1px dotted @700grey;
     }
-  }
+	}
+	
   .archive-meta {
 	  padding: 1em 0;
   }
@@ -158,6 +176,7 @@ a.more {
 span.next-page {
 	display: block;
 	margin-top: 50px;
+
 	a {
 	  padding: 10px 40px 10px 19px;
 	  text-transform: uppercase;
@@ -174,27 +193,27 @@ span.next-page {
 	  z-index: 1;
 	  line-height: 24px;
 	  font-size: 14px;
-	  font-weight: @extrabold;
-	  border-radius:0;
 	  -webkit-border-radius:0;
 	  -moz-border-radius:0;
+		border-radius:0;
+		
 	  &:after {
-		background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -206px -492px;
-		content: "";
-		position: absolute;
-		right: 17px;
-		top: 12px;
-		bottom: 3px;
-		width: 14px;
-		height: 21px;
-		//.rotate(90deg);
-	  }
+			background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -206px -492px;
+			content: "";
+			position: absolute;
+			right: 17px;
+			top: 12px;
+			bottom: 3px;
+			width: 14px;
+			height: 21px;
+			//.rotate(90deg);
+		}
+		
 	  &:hover {
-	  	 background-color: darken(@200grey, 5%);
+			background-color: darken(@200grey, 5%);
 	  }
 	}
 }
-
 
  // (doesn't include sidebar)
 
@@ -208,27 +227,29 @@ span.next-page {
 			//border-bottom: none;
 			color: @900grey;
 			border-bottom: 1px dotted @900grey;
+
 			&:visited {
 				color: @red;
 				border-bottom-color: @red;
 			}
 		}
 	}
+
 	a {
 		text-decoration: none;
 		border-bottom: 1px dotted @link;
 		//font-weight: 400;
-
 	}
+
 	p a:visited {
 	    color: @visited;
-	    border-bottom: 1px solid @visited;
+			border-bottom: 1px solid @visited;
+			
 	    &.uams-btn {
             border: none;
         }
     }
 }
-
 
 .info-box {
 	width: 310px;
@@ -242,18 +263,24 @@ span.next-page {
 	border-top: 6px solid @700grey;
 	position: relative;
 	background: url('assets/images/stripes-dark-tile.svg') repeat-x 0 -88px transparent;
+
 	img {
 		max-width: 100%;
 		height: auto;
 	}
+
 	&:after {
 		top: auto;
 		bottom: -40px;
 	}
-	p, li, a {
+
+	p,
+	li,
+	a {
 		font-size: floor(@font-size-base * 0.9);
 		line-height: 1.6;
 	}
+
 	h1, .h1,
 	h2, .h2, 
 	h3, .h3, 
@@ -262,6 +289,7 @@ span.next-page {
 		margin-top: 0;
 	}
 }
+
 .uams-body-copy ul.links {
 	overflow: visible;
 }
@@ -270,7 +298,8 @@ span.next-page {
 	padding: 0;
 	margin-top: 20px;
 	overflow: visible;
-	a {
+
+//	a {
 //		position: relative;
 //		&:after {
 //			background: url(/wp-content/themes/uams-2016/assets/svg/uams-sprite.svg) no-repeat -206px -492px;
@@ -283,13 +312,15 @@ span.next-page {
 //			height: 21px;
 //			.rotate(90deg);
 //		}
-	}
+//	}
+
 	li {
 		padding: 0;
 		list-style: none;
 		margin-bottom: 6px;
 		padding-bottom: 6px;
 		border-bottom: 1px solid @200grey;
+
 		&:last-child {
 			border-bottom: none;
 		}
@@ -299,9 +330,9 @@ span.next-page {
 img.attachment-post-thumbnail.wp-post-image,
 .archive .uams-body-copy img.attachment-thumbnail.wp-post-image {
 	float: left;
-    margin: 5px 50px 0 0;
-    height: 150px;
-    width: auto;
+	margin: 5px 50px 0 0;
+	height: 150px;
+	width: auto;
 
 	// Images on the blogroll page
 	&.blogroll-img {
@@ -313,20 +344,19 @@ img.attachment-post-thumbnail.wp-post-image,
 //Vertical Align
 .vertical-align {
 	position: relative;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    -moz-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    -o-transform: translateY(-50%);
-    transform: translateY(-50%);
+	top: 50%;
+	-webkit-transform: translateY(-50%);
+	-moz-transform: translateY(-50%);
+	-ms-transform: translateY(-50%);
+	-o-transform: translateY(-50%);
+	transform: translateY(-50%);
 }
-
-
 
 /* Small Devices, Tablets */
 @media only screen and (max-width : 767px) {
 	.uams-body {
-		padding: 20px;
+	padding: 20px;
+
 		.uams-site-title {
 			color: @red;
 			font-size: 25px;
@@ -337,41 +367,47 @@ img.attachment-post-thumbnail.wp-post-image,
 			position: static;
 			text-shadow: 0 1px 2px rgba(0,0,0,.2);
 		}
+
 		h1, .h1 {
 			margin: 10px 80px 20px 0;
 			font-size: 33px;
 		}
-        p.date {
-            margin-bottom: -15px;
-        }
-        .author-info {
-        	display: block;
-        }
-        .category-info {
-        	display: block;
-        	.category-list {
-        		padding-left: 0;
-        		border-left: none;
-        	}
-        }
+
+		p.date {
+			margin-bottom: -15px;
+		}
+
+		.author-info {
+			display: block;
+		}
+
+		.category-info {
+			display: block;
+
+			.category-list {
+				padding-left: 0;
+				border-left: none;
+			}
+		}
 	}
-    .home {
-        .uams-body {
-            .uams-page-title{
-                padding-right: 65px;
-             }
-        }
-    }
+
+	.home {
+		.uams-body {
+			.uams-page-title{
+				padding-right: 65px;
+			}
+		}
+	}
 }
 
 @media only screen and (min-width : 768px) {
-    .uams-body {
-        .uams-site-title {
-            &.long-title {
-                margin-top: 3px;
-            }
-        }
-    }
+	.uams-body {
+			.uams-site-title {
+					&.long-title {
+							margin-top: 3px;
+					}
+			}
+	}
 }
 
 // .home .uams-sidebar-menu {
@@ -382,7 +418,6 @@ img.attachment-post-thumbnail.wp-post-image,
 	padding: 10px 0 0 40px;
 }
 
-
 // Big Screens
 
 @media only screen and (max-width : 1600px) {
@@ -392,30 +427,31 @@ img.attachment-post-thumbnail.wp-post-image,
 }
 
 @media only screen and (max-width : 767px) {
-
 	.widget {
 		padding: 0;
 	}
+
 	.info-box {
 		margin-left: 0;
 		width: 100%;
 	}
-    .uams-body-copy {
+
+	.uams-body-copy {
 		h1, .h1,
 		h2, .h2,
 		h3, .h3,
 		h4, .h4,
 		p:first-of-type {
-            clear: right;
-        }
-        >div.row {
-            clear:both;
-        }
-    }
+			clear: right;
+		}
+
+		> div.row {
+			clear:both;
+		}
+	}
 
 }
 @media only screen and (min-width : 768px) {
-
 	.uams-body {
 		.uams-site-title {
 			text-shadow: 1px 1px 2px rgba(0,0,0,.5);

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -75,12 +75,16 @@ a.more {
 	padding-top: 10px;
 	-webkit-font-smoothing: antialiased;
 	letter-spacing: -0.022em;
-	h1, h2 {
+	h1, .h1,
+	h2, .h2 {
 		color: @red;
 		display: block;
 		letter-spacing: normal;
 	}
-	h2, h3, h4, h5 {
+	h2, .h2, 
+	h3, .h3, 
+	h4, .h4, 
+	h5, .h5 {
 		font-weight: @bold;
 		letter-spacing: normal;
 	}
@@ -188,17 +192,19 @@ span.next-page {
  // (doesn't include sidebar)
 
 .uams-body-copy {
-	h1 a,
-	h2 a,
-	h3 a,
-	h4 a,
-	h5 a {
-		//border-bottom: none;
-		color: @900grey;
-		border-bottom: 1px dotted @900grey;
-		&:visited {
-			color: @red;
-			border-bottom-color: @red;
+	h1, .h1,
+	h2, .h2, 
+	h3, .h3, 
+	h4, .h4, 
+	h5, .h5 {
+		a {
+			//border-bottom: none;
+			color: @900grey;
+			border-bottom: 1px dotted @900grey;
+			&:visited {
+				color: @red;
+				border-bottom-color: @red;
+			}
 		}
 	}
 	a {
@@ -241,7 +247,11 @@ span.next-page {
 		font-size: floor(@font-size-base * 0.9);
 		line-height: 1.6;
 	}
-	h1, h2, h3, h4, h5 {
+	h1, .h1,
+	h2, .h2, 
+	h3, .h3, 
+	h4, .h4, 
+	h5, .h5 {
 		margin-top: 0;
 	}
 }
@@ -320,7 +330,7 @@ img.attachment-post-thumbnail.wp-post-image,
 			position: static;
 			text-shadow: 0 1px 2px rgba(0,0,0,.2);
 		}
-		h1 {
+		h1, .h1 {
 			margin: 10px 80px 20px 0;
 			font-size: 33px;
 		}
@@ -384,7 +394,11 @@ img.attachment-post-thumbnail.wp-post-image,
 		width: 100%;
 	}
     .uams-body-copy {
-        h1,h2,h3,h4,p:first-of-type {
+		h1, .h1,
+		h2, .h2,
+		h3, .h3,
+		h4, .h4,
+		p:first-of-type {
             clear: right;
         }
         >div.row {

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -39,7 +39,7 @@ small,
 
 // Makes heavy
 .uams-body-copy .weight-900 {
-	font-weight: @ultra;
+	font-weight: @heavy;
 }
 
 a.more {
@@ -103,7 +103,7 @@ a.more {
 		font-family: @font-family-headline;
 		font-size: 50px;
 		line-height: 55px;
-		font-weight: @ultra;
+		font-weight: @heavy;
 		-webkit-font-smoothing: antialiased;
 		span {
 			font-weight: @extrabold;
@@ -130,7 +130,7 @@ a.more {
   }
   .author-info {
     margin: -4.5px 0 20px 0;
-    font-weight: @ultra;
+    font-weight: @heavy;
     display: inline-block;
   }
   .category-info {
@@ -324,7 +324,7 @@ img.attachment-post-thumbnail.wp-post-image,
 			color: @red;
 			font-size: 25px;
 			line-height: 1.2;
-			font-weight: @ultra;
+			font-weight: @heavy;
 			margin: -20px -20px 20px -20px;
 			padding: 15px 15px 15px 20px;
 			position: static;

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -85,7 +85,7 @@ a.more {
 	h3, .h3, 
 	h4, .h4, 
 	h5, .h5 {
-		font-weight: @bold;
+		font-weight: @extrabold;
 		letter-spacing: normal;
 	}
 	blockquote {
@@ -106,7 +106,7 @@ a.more {
 		font-weight: @ultra;
 		-webkit-font-smoothing: antialiased;
 		span {
-			font-weight: @bold;
+			font-weight: @extrabold;
 		}
 	}
 	a.uams-site-title {
@@ -156,7 +156,7 @@ span.next-page {
 	  text-transform: uppercase;
 	  background-color: @200grey;
 	  font-family: @font-family-headline;
-	  font-weight: @bold;
+	  font-weight: @extrabold;
 	  color: @800grey;
 	  display: inline-block;
 	  position: relative;
@@ -167,7 +167,7 @@ span.next-page {
 	  z-index: 1;
 	  line-height: 24px;
 	  font-size: 14px;
-	  font-weight: @bold;
+	  font-weight: @extrabold;
 	  border-radius:0;
 	  -webkit-border-radius:0;
 	  -moz-border-radius:0;

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -75,18 +75,22 @@ a.more {
 	padding-top: 10px;
 	-webkit-font-smoothing: antialiased;
 	letter-spacing: -0.022em;
+
+	h1, .h1,
+	h2, .h2, 
+	h3, .h3, 
+	h4, .h4, 
+	h5, .h5, 
+	h6, .h6 {
+		letter-spacing: normal;
+	}
+	h1, .h1 {
+		font-weight: @extrabold;
+	}
 	h1, .h1,
 	h2, .h2 {
 		color: @red;
 		display: block;
-		letter-spacing: normal;
-	}
-	h2, .h2, 
-	h3, .h3, 
-	h4, .h4, 
-	h5, .h5 {
-		font-weight: @extrabold;
-		letter-spacing: normal;
 	}
 	blockquote {
 		border-left: 3px solid @300grey;

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -118,7 +118,7 @@ a.more {
 		font-family: @font-family-headline;
 		font-size: 50px;
 		line-height: 55px;
-		font-weight: @heavy;
+		font-weight: @heading;
 		-webkit-font-smoothing: antialiased;
 
 		span {
@@ -182,7 +182,7 @@ span.next-page {
 	  text-transform: uppercase;
 	  background-color: @200grey;
 	  font-family: @font-family-headline;
-	  font-weight: @extrabold;
+	  font-weight: @heading;
 	  color: @800grey;
 	  display: inline-block;
 	  position: relative;

--- a/less/uams.body-content.less
+++ b/less/uams.body-content.less
@@ -4,6 +4,9 @@ ul {
 	padding-left: 25px;
 	//list-style-position: inside;
 }
+dt {
+	font-weight: @heading;
+}
 dd {
 	margin-bottom: 24.5px;
 }

--- a/less/uams.buttons.less
+++ b/less/uams.buttons.less
@@ -5,7 +5,7 @@ a.uams-btn {
   text-transform: uppercase;
   background-color: @300grey;
   font-family: @font-family-headline;
-  font-weight: @bold;
+  font-weight: @extrabold;
   color: @700grey;
   display: inline-block;
   position: relative;
@@ -19,7 +19,7 @@ a.uams-btn {
   &.btn-sm {
     padding: 8px 14px;
     font-size: floor(@font-size-base * 0.8);
-    font-weight: @bold;
+    font-weight: @extrabold;
     border-radius:0;
     -webkit-border-radius:0;
     -moz-border-radius:0;
@@ -67,7 +67,7 @@ a.uams-btn {
   &.btn-lg {
     padding: 16px 30px;
     font-size: floor(@font-size-base * 1.3);
-    font-weight: @bold;
+    font-weight: @extrabold;
     border-radius:0;
     -webkit-border-radius:0;
     -moz-border-radius:0;

--- a/less/uams.buttons.less
+++ b/less/uams.buttons.less
@@ -5,7 +5,7 @@ a.uams-btn {
   text-transform: uppercase;
   background-color: @300grey;
   font-family: @font-family-headline;
-  font-weight: @extrabold;
+  font-weight: @heading;
   color: @700grey;
   display: inline-block;
   position: relative;
@@ -19,7 +19,7 @@ a.uams-btn {
   &.btn-sm {
     padding: 8px 14px;
     font-size: floor(@font-size-base * 0.8);
-    font-weight: @extrabold;
+    //font-weight: @extrabold;
     border-radius:0;
     -webkit-border-radius:0;
     -moz-border-radius:0;
@@ -67,7 +67,7 @@ a.uams-btn {
   &.btn-lg {
     padding: 16px 30px;
     font-size: floor(@font-size-base * 1.3);
-    font-weight: @extrabold;
+    //font-weight: @extrabold;
     border-radius:0;
     -webkit-border-radius:0;
     -moz-border-radius:0;

--- a/less/uams.cards.less
+++ b/less/uams.cards.less
@@ -49,7 +49,7 @@
         }
         .card-content {
             flex-grow: 1;
-            h3 {
+            h3, .h3 {
                 margin-top: 0;
                 color: #9d2235;
             }
@@ -68,7 +68,7 @@
         &.right {
             flex-direction: row;
             flex: 1 0 100%;
-            h3 {
+            h3, .h3 {
                 font-size: 1.1em;
             }
             .card-image {

--- a/less/uams.carousel.less
+++ b/less/uams.carousel.less
@@ -1105,7 +1105,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	}
 
 	.jp-carousel-close-hint {
-	 	font-weight: @ultra !important;
+	 	font-weight: @heavy !important;
 		font-size: 26px !important;
 		position: fixed !important;
 		top: -10px;

--- a/less/uams.carousel.less
+++ b/less/uams.carousel.less
@@ -69,20 +69,22 @@ only screen and (min-device-pixel-ratio: 1.5) {
 	transition: 400ms ease-out;
 }
 
-.jp-carousel-info h2 {
-	background: none !important;
-	border: none !important;
-	color: @700grey;
-	display: block !important;
-	font: normal 13px/1.25em "Helvetica Neue", sans-serif !important;
-	letter-spacing: 0 !important;
-	margin: 7px 0 0 0 !important;
-	padding: 10px 0 0 !important;
-	overflow: hidden;
-	text-align: left;
-	text-shadow: none !important;
-	text-transform: none !important;
-	-webkit-font-smoothing: subpixel-antialiased;
+.jp-carousel-info {
+	h2, .h2 {
+		background: none !important;
+		border: none !important;
+		color: @700grey;
+		display: block !important;
+		font: normal 13px/1.25em "Helvetica Neue", sans-serif !important;
+		letter-spacing: 0 !important;
+		margin: 7px 0 0 0 !important;
+		padding: 10px 0 0 !important;
+		overflow: hidden;
+		text-align: left;
+		text-shadow: none !important;
+		text-transform: none !important;
+		-webkit-font-smoothing: subpixel-antialiased;
+	}
 }
 
 .jp-carousel-next-button,
@@ -476,14 +478,17 @@ div#carousel-reblog-box {
 	margin-bottom: 0.75em;
 }
 
-.jp-carousel-titleanddesc p a,
-.jp-carousel-comments p a,
-.jp-carousel-info h2 a {
-	color: #fff !important;
-	border: none !important;
-	text-decoration: underline !important;
-	font-weight: normal !important;
-	font-style: normal !important;
+.jp-carousel-titleanddesc p,
+.jp-carousel-comments p,
+.jp-carousel-info h2,
+.jp-carousel-info .h2 {
+	a {
+		color: #fff !important;
+		border: none !important;
+		text-decoration: underline !important;
+		font-weight: normal !important;
+		font-style: normal !important;
+	}
 }
 
 .jp-carousel-titleanddesc p strong,
@@ -499,21 +504,27 @@ div#carousel-reblog-box {
 }
 
 
-.jp-carousel-titleanddesc p a:hover,
-.jp-carousel-comments p a:hover,
-.jp-carousel-info h2 a:hover {
-	color: #68c9e8 !important;
+.jp-carousel-titleanddesc p,
+.jp-carousel-comments p,
+.jp-carousel-info h2,
+.jp-carousel-info .h2 {
+	a:hover {
+		color: #68c9e8 !important;
+	}
 }
 
 .jp-carousel-titleanddesc p:empty {
 	display: none;
 }
 
-.jp-carousel-photo-info h1:before,
-.jp-carousel-photo-info h1:after,
-.jp-carousel-left-column-wrapper h1:before,
-.jp-carousel-left-column-wrapper h1:after {
-	content:none !important;
+.jp-carousel-photo-info,
+.jp-carousel-left-column-wrapper {
+	h1, .h1 {
+		&:before,
+		&:after {
+			content:none !important;
+		}
+	}
 }
 /** Title and Desc End **/
 
@@ -527,42 +538,38 @@ div#carousel-reblog-box {
 	overflow: hidden;
 	padding: 18px 20px;
 	width: 209px !important;
-}
+	li,
+	h5, .h5 {
+		font-family: "Helvetica Neue", sans-serif !important;
+		position: inherit !important;
+		top: auto !important;
+		right: auto !important;
+		left: auto !important;
+		bottom: auto !important;
+		background: none !important;
+		border: none !important;
+		font-weight: 400 !important;
+		line-height: 1.3em !important;
+		color: @500grey !important;
+		text-transform: uppercase !important;
+		font-size:10px !important;
+		margin:0 0 2px !important;
+		letter-spacing: 0.1em !important;
+	}
 
-.jp-carousel-image-meta li,
-.jp-carousel-image-meta h5 {
-	font-family: "Helvetica Neue", sans-serif !important;
-	position: inherit !important;
-	top: auto !important;
-	right: auto !important;
-	left: auto !important;
-	bottom: auto !important;
-	background: none !important;
-	border: none !important;
-	font-weight: 400 !important;
-	line-height: 1.3em !important;
-}
+	ul {
+		margin: 0 !important;
+		padding: 0 !important;
+		list-style: none !important;
+	}
 
-.jp-carousel-image-meta ul {
-	margin: 0 !important;
-	padding: 0 !important;
-	list-style: none !important;
-}
-
-.jp-carousel-image-meta li {
-	width: 48% !important;
-	float: left !important;
-	margin: 0 2% 15px 0 !important;
-	color: #fff !important;
-	font-size:13px !important;
-}
-
-.jp-carousel-image-meta h5 {
-	color: @500grey !important;
-	text-transform: uppercase !important;
-	font-size:10px !important;
-	margin:0 0 2px !important;
-	letter-spacing: 0.1em !important;
+	li {
+		width: 48% !important;
+		float: left !important;
+		margin: 0 2% 15px 0 !important;
+		color: #fff !important;
+		font-size:13px !important;
+	}
 }
 
 a.jp-carousel-image-download {
@@ -864,49 +871,52 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 
 /* ----- Light variant ----- */
 
-.jp-carousel-light .jp-carousel-overlay {
-	background: #fff;
-}
 
-.jp-carousel-light .jp-carousel-next-button:hover span,
-.jp-carousel-light .jp-carousel-previous-button:hover span {
-	opacity: 0.8;
-}
+.jp-carousel-light {
+	.jp-carousel-overlay {
+		background: #fff;
+	}
 
-.jp-carousel-light .jp-carousel-close-hint:hover,
-.jp-carousel-light .jp-carousel-titleanddesc div {
-	color: #000 !important;
-}
+	.jp-carousel-next-button:hover,
+	.jp-carousel-previous-button:hover {
+		span {
+			opacity: 0.8;
+		}
+	}
 
-.jp-carousel-light .jp-carousel-comments p a,
-.jp-carousel-light .jp-carousel-comment .comment-author a,
-.jp-carousel-light .jp-carousel-titleanddesc p a,
-.jp-carousel-light .jp-carousel-titleanddesc p a,
-.jp-carousel-light .jp-carousel-comments p a,
-.jp-carousel-light .jp-carousel-info h2 a {
-	color: @steel !important;
-}
+	.jp-carousel-close-hint:hover,
+	.jp-carousel-titleanddesc div {
+		color: #000 !important;
+	}
 
-.jp-carousel-light .jp-carousel-comments p a:hover,
-.jp-carousel-light .jp-carousel-comment .comment-author a:hover,
-.jp-carousel-light .jp-carousel-titleanddesc p a:hover,
-.jp-carousel-light .jp-carousel-titleanddesc p a:hover,
-.jp-carousel-light .jp-carousel-comments p a:hover,
-.jp-carousel-light .jp-carousel-info h2 a:hover {
-	color: @alert !important;
-}
+	.jp-carousel-comments p,
+	.jp-carousel-comment .comment-author,
+	.jp-carousel-titleanddesc p,
+	.jp-carousel-comments p,
+	.jp-carousel-info h2,
+	.jp-carousel-info .h2 {
+		a {
+			color: @steel !important;
 
-.jp-carousel-light .jp-carousel-info h2,
-.jp-carousel-light .jp-carousel-titleanddesc,
-.jp-carousel-light .jp-carousel-titleanddesc p,
-.jp-carousel-light .jp-carousel-comment,
-.jp-carousel-light .jp-carousel-comment p,
-.jp-carousel-light div.jp-carousel-buttons a,
-.jp-carousel-light .jp-carousel-titleanddesc p strong,
-.jp-carousel-light .jp-carousel-titleanddesc p b,
-.jp-carousel-light .jp-carousel-titleanddesc p em,
-.jp-carousel-light .jp-carousel-titleanddesc p i {
-	color: @700grey;
+			&:hover {
+				color: @alert !important;
+			}
+		}
+	}
+
+	.jp-carousel-info h2,
+	.jp-carousel-info .h2,
+	.jp-carousel-titleanddesc,
+	.jp-carousel-titleanddesc p,
+	.jp-carousel-comment,
+	.jp-carousel-comment p,
+	div.jp-carousel-buttons a,
+	.jp-carousel-titleanddesc p strong,
+	.jp-carousel-titleanddesc p b,
+	.jp-carousel-titleanddesc p em,
+	.jp-carousel-titleanddesc p i {
+		color: @700grey;
+	}
 }
 
 .jp-carousel-light .jp-carousel-buttons {

--- a/less/uams.dropdowns.less
+++ b/less/uams.dropdowns.less
@@ -50,7 +50,7 @@
 	&.reddiedrops-item {
 		a {
 		font-family: @font-family-headline;
-		font-weight: @extrabold;
+		font-weight: @heading;
 		font-size: floor(@font-size-base * 1.111);
 		padding: 5px 10px 21px 15px;
 			&:focus,
@@ -61,7 +61,7 @@
 		li a {
 			font-family: @font-family-headline;
 			text-transform: none;
-			font-weight: @semibold;
+			font-weight: @heading;
 			padding-bottom: 4px;
 			padding-left: 10px;
 			padding-top: 4px;

--- a/less/uams.dropdowns.less
+++ b/less/uams.dropdowns.less
@@ -50,7 +50,7 @@
 	&.reddiedrops-item {
 		a {
 		font-family: @font-family-headline;
-		font-weight: @bold;
+		font-weight: @extrabold;
 		font-size: floor(@font-size-base * 1.111);
 		padding: 5px 10px 21px 15px;
 			&:focus,
@@ -238,7 +238,7 @@
   		font-size: floor(@font-size-base * 1.111);
   		text-transform: none;
   		color: #FFF;
-  		font-weight: @bold;
+  		font-weight: @extrabold;
   		position: absolute;
   		top: 65px;
   		right: 0;

--- a/less/uams.dropdowns.less
+++ b/less/uams.dropdowns.less
@@ -80,7 +80,7 @@
 		li li a {
 			font-family: @font-family-headline;
 			text-transform: none;
-			font-weight: @light;
+			font-weight: @regular;
 			letter-spacing: -0.03em;
 			padding-bottom: 4px;
 			padding-left: 10px;

--- a/less/uams.dropdowns.less
+++ b/less/uams.dropdowns.less
@@ -61,7 +61,7 @@
 		li a {
 			font-family: @font-family-headline;
 			text-transform: none;
-			font-weight: @medium;
+			font-weight: @semibold;
 			padding-bottom: 4px;
 			padding-left: 10px;
 			padding-top: 4px;

--- a/less/uams.footer.less
+++ b/less/uams.footer.less
@@ -35,7 +35,7 @@
     //  opacity: 1;
     //}
 	//}
-	h4 {
+	h4, .h4 {
 		font-family: "Fira Sans", sans-serif;
 		color: #fff;
 		font-weight: 400;
@@ -145,7 +145,7 @@
 			background-size: 655px;
 			width: 240px;
 		}
-		h4 {
+		h4, .h4 {
 			&:after {
 				display: none;
 			}

--- a/less/uams.hero.less
+++ b/less/uams.hero.less
@@ -38,7 +38,7 @@
 				line-height: 1;
 				padding: 40px 20% 0 0;
 				margin: 0;
-				text-shadow: 1px 3px rgba(0,0,0,.5);
+				text-shadow: @hero-shadow-dark;
 				&:after {
 					content: "";
 					display: block;
@@ -58,7 +58,7 @@
 			h2, .h2 { // For sub-titles
 				color: @white;
 				line-height: 1;
-				text-shadow: 1px 3px rgba(0,0,0,.5);
+				text-shadow: @hero-shadow-dark;
 			}
   		}
   		&:after{

--- a/less/uams.hero.less
+++ b/less/uams.hero.less
@@ -34,7 +34,7 @@
   			padding-left: 0;
 			position: static;
 			padding-bottom: 20px;
-  			h1 {
+  			h1, .h1 {
 				line-height: 1;
 				padding: 40px 20% 0 0;
 				margin: 0;
@@ -55,7 +55,7 @@
 					transform: translateY(-50%);
 				}
 			}
-			h2 { // For sub-titles
+			h2, .h2 { // For sub-titles
 				color: @white;
 				line-height: 1;
 				text-shadow: 1px 3px rgba(0,0,0,.5);
@@ -160,14 +160,16 @@
 		      -moz-background-size: cover;
 		      -o-background-size: cover;
 		      background-size: cover;
-		    }
+		  }
 
-		    #hero-bg {
+		  #hero-bg {
 				//top: 20px;
-			    #hero-container h1.uams-site-title ,
-			    div.container h1.uams-site-title2 {
+				#hero-container h1.uams-site-title,
+				#hero-container .h1.uams-site-title,
+				div.container h1.uams-site-title2,
+				div.container .h1.uams-site-title2 {
 					padding-top: 40px;
-				    &:after{
+				    &:after {
 				    	background: none;
 				    }
 				}
@@ -184,25 +186,25 @@
 		&.hero-height {
 			padding: 50px 20px 20px;
 			display: block;
-		  	height: 240px;
+		  height: 240px;
 		  	#hero-bg{
 			  	top: 50%;
 		  	}
 		  	#hero-container {
-		  		h1 {
+		  		h1, .h1 {
 		  			font-size: 35px;
 		  			padding: 0;
 		  			&:after {
 		  				background-size: 80%;
 		  				-moz-background-size: 80%;
 		  				-webkit-background-size: 80%;
-// 						top: -60px;
-						left: -270px;
+ 							//top: -60px;
+							left: -270px;
 		  			}
-				}
-				h2 {
-					font-size: 26px;
-				}
+					}
+					h2, .h2 {
+						font-size: 26px;
+					}
 		  	}
 		}
 		// Smaller hero
@@ -212,16 +214,16 @@
 		  	height: auto;
 		  	.container {
 		  	}
-		  	h1 {
+		  	h1, .h1 {
 		  		font-size: 35px;
 		  		padding: 0;
 		  		&:after {
 		  			background-size: 100%;
 		  			-moz-background-size: 100%;
 		  			-webkit-background-size: 100%;
-					//top: -60px;
-					left: -270px;
-					height: 100vh;
+						//top: -60px;
+						left: -270px;
+						height: 100vh;
 		  		}
 		  	}
 		}

--- a/less/uams.heroimage.less
+++ b/less/uams.heroimage.less
@@ -28,7 +28,7 @@
 	position: relative;
 	z-index: 1;
 	padding-bottom: 20px;
-	h1 {
+	h1, .h1 {
 		font-family: @font-family-headline;
 		text-transform: uppercase;
 		font-weight: @bold;
@@ -64,8 +64,10 @@
 	color: @red;
 }
 .no-title {
-	h1.uams-site-title-blank {
-		display: none;
+	h1, .h1 {
+		&.uams-site-title-blank {
+			display: none;
+		}
 	}
 }
 
@@ -96,7 +98,7 @@
 			}
 		}
 	}
-	h1 {
+	h1, .h1 {
 		text-transform: uppercase;
     	color: white;
     	font-weight: @bold;
@@ -128,7 +130,8 @@
 	}
 	&:before {
 		display: none;
-	}&:after {
+	}
+	&:after {
 		display: none;
 	}
 	.udub-slant {
@@ -161,7 +164,7 @@
 	}
 	.hero-height2 {
 		.container {
-	  		top: inherit%;
+	  		top: inherit;
 	  		-webkit-transform: none;
 	  		-ms-transform: none;
 	  		transform: none;

--- a/less/uams.heroimage.less
+++ b/less/uams.heroimage.less
@@ -31,7 +31,7 @@
 	h1, .h1 {
 		font-family: @font-family-headline;
 		text-transform: uppercase;
-		font-weight: @bold;
+		font-weight: @extrabold;
 		font-size: 75px;
 		color: white;
 		&.hero-text-dark {
@@ -41,7 +41,7 @@
 
 	p {
 		color: #fff;
-		font-weight: @bold;
+		font-weight: @extrabold;
 		font-size: 1.1em;
 		line-height: 23px;
 		margin: 0 0 30px;
@@ -101,7 +101,7 @@
 	h1, .h1 {
 		text-transform: uppercase;
     	color: white;
-    	font-weight: @bold;
+    	font-weight: @extrabold;
     	font-size: 60px;
     	margin: 0;
     	line-height: 1;

--- a/less/uams.heroimage.less
+++ b/less/uams.heroimage.less
@@ -31,7 +31,7 @@
 	h1, .h1 {
 		font-family: @font-family-headline;
 		text-transform: uppercase;
-		font-weight: @extrabold;
+		font-weight: @heading;
 		font-size: 75px;
 		color: white;
 		&.hero-text-dark {
@@ -41,7 +41,7 @@
 
 	p {
 		color: #fff;
-		font-weight: @extrabold;
+		font-weight: @heading;
 		font-size: 1.1em;
 		line-height: 23px;
 		margin: 0 0 30px;

--- a/less/uams.heroimage.less
+++ b/less/uams.heroimage.less
@@ -105,7 +105,7 @@
     	font-size: 60px;
     	margin: 0;
     	line-height: 1;
-		text-shadow: 1px 2px rgba(0,0,0,0.5);
+		text-shadow: @hero-shadow-dark;
 		display: inline-block;
   		vertical-align: bottom;
 		&:after {

--- a/less/uams.homeslider.less
+++ b/less/uams.homeslider.less
@@ -3,42 +3,52 @@
 .uams-homepage-slider-container {
 	position: relative;
 	height: 450px;
+
 	.slideshow-controls {
 		&:hover {
-				text-shadow: 3px 4px black;
+			text-shadow: 3px 4px black;
+		}
+
+		&.lighttext .next-headline{
+			text-shadow: 2px 2px rgba(0, 0, 0, 0.5);
+			background-color: rgba(0, 0, 0, 0.25);
+
+			.uwn-slideshow-next-text {
+				color: @gray;
 			}
-			&.lighttext .next-headline{
-				text-shadow: 2px 2px rgba(0, 0, 0, 0.5);
-				background-color: rgba(0, 0, 0, 0.25);
-				.uwn-slideshow-next-text {
-					color: @gray;
-				}
-				.uwn-slideshow-next-title {
-					color: white;
-				}
-				.udub-slant span {
-					background-color: white;
-				}
-				&:before {
-					background: url(../uams-2016/assets/svg/uams-sprite.svg) no-repeat -574px -55px;
-				}
+
+			.uwn-slideshow-next-title {
+				color: white;
 			}
-			&.darktext .next-headline{
-				text-shadow: 2px 2px rgba(255, 255, 255, 0.5);
-				background-color: rgba(255, 255, 255, 0.25);
-				.uwn-slideshow-next-text {
-					color: @red;
-				}
-				.uwn-slideshow-next-title {
-					color: @900grey;
-				}
-				.udub-slant span {
-					background-color: @900grey;
-				}
-				&:before {
-					background: url(../uams-2016/assets/svg/uams-sprite-focus.svg) no-repeat -574px -55px;
-				}
+
+			.udub-slant span {
+				background-color: white;
 			}
+
+			&:before {
+				background: url(../uams-2016/assets/svg/uams-sprite.svg) no-repeat -574px -55px;
+			}
+		}
+		&.darktext .next-headline{
+			text-shadow: 2px 2px rgba(255, 255, 255, 0.5);
+			background-color: rgba(255, 255, 255, 0.25);
+
+			.uwn-slideshow-next-text {
+				color: @red;
+			}
+
+			.uwn-slideshow-next-title {
+				color: @900grey;
+			}
+
+			.udub-slant span {
+				background-color: @900grey;
+			}
+
+			&:before {
+				background: url(../uams-2016/assets/svg/uams-sprite-focus.svg) no-repeat -574px -55px;
+			}
+		}
 		.next-headline{
 			background: 0 0;
 		    border: none;
@@ -52,21 +62,23 @@
 			//height: 112px;
 			width: 280px;
 			line-height: 17px;
-
 			text-align: left;
 			cursor: pointer;
 			padding: 14px 14px 20px 44px;
 			z-index: 1;
+
 			.uwn-slideshow-next-text {
 				font-weight: bold;
 				font-style: italic;
 				font-size: floor(@font-size-base * 1.111);
 				line-height: floor(@font-size-base * 1.9);
+
 				&:after {
 					content: "\A";
 					white-space: pre;
 				}
 			}
+
 			&:before {
 				content: "";
 			    position: absolute;
@@ -76,17 +88,19 @@
 			    width: 16px;
 			    height: 28px;
 			}
+
 			.uwn-slideshow-next-title {
 				font-weight: bold;
 				cursor: pointer;
 				font-size: floor(@font-size-base * 1.111);
 			}
+
 			.udub-slant span {
 				height: 5px; width: 57px;
 			}
-
 		}
 	}
+
 	.uams-homepage-slider {
 		position: absolute;
 		top: 0;
@@ -97,10 +111,12 @@
 		z-index: 1;
 		transition: opacity 1s;
 		pointer-events: none;
+
 		&.activeslide {
 			opacity: 1;
 			pointer-events: auto;
 		}
+
 		div {
 			padding: 24px;
 			h3, .h3 {
@@ -109,17 +125,20 @@
 					line-height: ceil(@font-size-base * 2.66);
 					/* text-transform: uppercase; */ //Removed for Nursing, et al
 					margin: 0;
+
 					.udub-slant span {
 						background-color: @red;
 					}
 				}
 			}
+
 			p {
 				font-size: floor(@font-size-base * 1.111);;
 				line-height: 28px;
 				font-weight: 400;
 			}
 		}
+
 		&.lighttext {
 			div {
 				h3, .h3,
@@ -129,6 +148,7 @@
 				}
 			}
 		}
+
 		&.darktext {
 			div {
 				h3, .h3,
@@ -140,6 +160,7 @@
 		}
 	}
 }
+
 @media only screen and (max-width: 767px) {
 	.uams-homepage-slider-container {
 		.uams-homepage-slider {
@@ -150,50 +171,63 @@
 						line-height: ceil(@font-size-base * 1.2);
 					}
 				}
+
 				p {
 					font-size: floor(@font-size-base * 0.9);
 					line-height: floor(@font-size-base * 1.111);
 				}
 			}
 		}
+
 		.slideshow-controls {
 			position: absolute;
 			left: 35px;
 			bottom: 0;
+
 			.next-headline {
 			    position: relative;
 			    width: auto;
 			    padding: 0 40px 10px 5px;
-			    right:auto;
+				right:auto;
+				
 			    &:before {
 				    right: 10px;
 				    left: auto;
 				    top: 36px;
-			    }
+				}
+				
 			    .udub-slant {
 				    display: none;
 			    }
 			}
 		}
 	}
+
 	.uams-hero-image {
 		display: block !important;
 	}
 }
+
 @media only screen and (max-width: 991px) and (min-width: 768px) {
 	.uams-homepage-slider-container {
 		.slideshow-controls {
-			 right: auto; left: 50px;
-			 .next-headline { right:10%; }
+			right: auto; left: 50px;
+
+			.next-headline {
+				right:10%;
+			}
 		}
+
 		.uams-homepage-slider {
 			 div {
-				 padding-left: 48px;
+				padding-left: 48px;
+
 				p {
 					padding-right: 45%;
 					font-size: floor(@font-size-base * 0.95);
 					line-height: floor(@font-size-base * 1.2);
-		    	}
+				}
+				
 		    	h3, .h3 {
 					&.slide-title {
 						.udub-slant {
@@ -205,16 +239,26 @@
 	    }
     }
 }
+
 @media only screen and (max-width: 1199px) and (min-width: 992px) {
-	.uams-homepage-slider-container .slideshow-controls { right: 480px; }
+	.uams-homepage-slider-container {
+		.slideshow-controls {
+			right: 480px;
+		}
+	}
 }
+
 @media (min-width: 992px) {
 	.uams-homepage-slider-container {
 		height: 430px;
+
 		.uams-homepage-slider div {
 			margin: 25px auto 45px;
 			width: 970px;
-			p { width: 50%;}
+
+			p {
+				width: 50%;
+			}
 		}
 	}
 }
@@ -223,6 +267,7 @@
 		margin: 35px auto 45px;
 		width: 1170px;
 	}
+
 	.uams-homepage-slider-container .uams-homepage-slider div p {
 		width: 44%;
 	}

--- a/less/uams.homeslider.less
+++ b/less/uams.homeslider.less
@@ -103,13 +103,15 @@
 		}
 		div {
 			padding: 24px;
-			h3.slide-title {
-				font-size: ceil(@font-size-base * 2.5);
-				line-height: ceil(@font-size-base * 2.66);
-				/* text-transform: uppercase; */ //Removed for Nursing, et al
-				margin: 0;
-				.udub-slant span {
-					background-color: @red;
+			h3, .h3 {
+				&.slide-title {
+					font-size: ceil(@font-size-base * 2.5);
+					line-height: ceil(@font-size-base * 2.66);
+					/* text-transform: uppercase; */ //Removed for Nursing, et al
+					margin: 0;
+					.udub-slant span {
+						background-color: @red;
+					}
 				}
 			}
 			p {
@@ -120,7 +122,8 @@
 		}
 		&.lighttext {
 			div {
-				h3, p {
+				h3, .h3,
+				p {
 					color: #fff;
 					text-shadow: 1px 1px rgba(0, 0, 0, 0.3);
 				}
@@ -128,7 +131,8 @@
 		}
 		&.darktext {
 			div {
-				h3, p {
+				h3, .h3,
+				p {
 					color: @900grey;
 					text-shadow: 1px 1px rgba(225, 225, 225, 0.3);
 				}
@@ -140,9 +144,11 @@
 	.uams-homepage-slider-container {
 		.uams-homepage-slider {
 			div {
-				h3.slide-title {
-					font-size: floor(@font-size-base * 1.2);
-					line-height: ceil(@font-size-base * 1.2);
+				h3, .h3 {
+					&.slide-title {
+						font-size: floor(@font-size-base * 1.2);
+						line-height: ceil(@font-size-base * 1.2);
+					}
 				}
 				p {
 					font-size: floor(@font-size-base * 0.9);
@@ -188,10 +194,12 @@
 					font-size: floor(@font-size-base * 0.95);
 					line-height: floor(@font-size-base * 1.2);
 		    	}
-		    	h3.slide-title {
-			    	.udub-slant {
-				    	margin: 20px 0 10px 0;
-			    	}
+		    	h3, .h3 {
+					&.slide-title {
+						.udub-slant {
+							margin: 20px 0 10px 0;
+						}
+					}
 		    	}
 		    }
 	    }

--- a/less/uams.homeslider.less
+++ b/less/uams.homeslider.less
@@ -67,11 +67,18 @@
 			padding: 14px 14px 20px 44px;
 			z-index: 1;
 
+			.uwn-slideshow-next-text,
+			.uwn-slideshow-next-title {
+				display:block;
+				line-height:1;
+			}
+
 			.uwn-slideshow-next-text {
-				font-weight: bold;
+				display:block;
+				margin-bottom:0.25em;
+				font-weight: @semibold;
 				font-style: italic;
 				font-size: floor(@font-size-base * 1.111);
-				line-height: floor(@font-size-base * 1.9);
 
 				&:after {
 					content: "\A";
@@ -90,7 +97,8 @@
 			}
 
 			.uwn-slideshow-next-title {
-				font-weight: bold;
+				display:block;
+				font-weight: @bold;
 				cursor: pointer;
 				font-size: floor(@font-size-base * 1.111);
 			}
@@ -135,7 +143,7 @@
 			p {
 				font-size: floor(@font-size-base * 1.111);;
 				line-height: 28px;
-				font-weight: 400;
+				font-weight: @regular;
 			}
 		}
 
@@ -144,7 +152,7 @@
 				h3, .h3,
 				p {
 					color: #fff;
-					text-shadow: 1px 1px rgba(0, 0, 0, 0.3);
+					text-shadow: @hero-shadow-dark;
 				}
 			}
 		}
@@ -154,7 +162,7 @@
 				h3, .h3,
 				p {
 					color: @900grey;
-					text-shadow: 1px 1px rgba(225, 225, 225, 0.3);
+					text-shadow: @hero-shadow-light;
 				}
 			}
 		}

--- a/less/uams.mobile-menu.less
+++ b/less/uams.mobile-menu.less
@@ -55,7 +55,7 @@
       font-size: @font-size-base / 1.2;
       line-height: @line-height-base / 1.2;
       font-family: @font-family-headline;
-      font-weight: @bold;
+      font-weight: @extrabold;
       text-align: center;
       width: 50px;
       height: 40px;

--- a/less/uams.mobile-sidebar-menu.less
+++ b/less/uams.mobile-sidebar-menu.less
@@ -40,7 +40,7 @@
 	 	display:inline;
 	 	float:left;
 	 	//font-size:16px;
-	 	font-weight: @bold;
+	 	font-weight: @extrabold;
 	}
 
 	#ham {

--- a/less/uams.post-content.less
+++ b/less/uams.post-content.less
@@ -1,5 +1,7 @@
-h1.post-link-title {
-	margin-left: 1.2em;
+h1, .h1 {
+  &.post-link-title {
+    margin-left: 1.2em;
+  }
 }
 .post-link-icon {
   	color: #e0e0e0;

--- a/less/uams.quicklinks.less
+++ b/less/uams.quicklinks.less
@@ -70,7 +70,7 @@
 
 	    }
 
-		h3 {
+		h3, .h3 {
 	        font-size: @font-size-h6;
 	        color: white;
 	        margin: 40px 0 30px 0;
@@ -85,7 +85,7 @@
 			  	bottom: -19px;
 	        }
       	}
-	  	h4 {
+	  	h4, .h4 {
 	        font-size: @font-size-h6;
 	        color: white;
 	        margin: 20px 0 15px 0;

--- a/less/uams.search.less
+++ b/less/uams.search.less
@@ -96,7 +96,7 @@ body.search-open #uamssearcharea {
       margin-bottom: -5px;
       font-family: @font-family-headline;
       font-size: 16px;
-      font-weight: @bold;
+      font-weight: @extrabold;
       cursor: pointer;
     }
   }

--- a/less/uams.search.less
+++ b/less/uams.search.less
@@ -169,7 +169,7 @@ body.search-open #uamssearcharea {
         background: url('assets/images/search-vcard.png') no-repeat 0 6px;
       }
       &.open {
-        h4 {
+        h4, .h4 {
           color: @red;
         }
         a.directory-more {
@@ -183,7 +183,7 @@ body.search-open #uamssearcharea {
       }
     }
 
-    h4 {
+    h4, .h4 {
       width: 100%;
       font-size: 18px;
       color: #757575;
@@ -297,7 +297,7 @@ body {
       }
     }
     .uams-results {
-      h4 {
+      h4, .h4 {
         padding: 15px 60px 15px 14px;
       }
       .result {

--- a/less/uams.search.less
+++ b/less/uams.search.less
@@ -96,7 +96,7 @@ body.search-open #uamssearcharea {
       margin-bottom: -5px;
       font-family: @font-family-headline;
       font-size: 16px;
-      font-weight: @extrabold;
+      font-weight: @heading;
       cursor: pointer;
     }
   }

--- a/less/uams.select.less
+++ b/less/uams.select.less
@@ -26,7 +26,7 @@ ul.uams-select {
   li {
     cursor: pointer;
     color: #565656;
-    font-weight: @bold;
+    font-weight: @extrabold;
     transition: padding-left 0.5s;
     opacity: 0;
     transition: opacity .5s;

--- a/less/uams.sidebar.less
+++ b/less/uams.sidebar.less
@@ -1,15 +1,13 @@
 ul.uams-sidebar-menu,
-ul.uams-mobile-menu
-
-{
+ul.uams-mobile-menu {
 	margin-left: 20px;
 	margin-right: -20px;
 	padding: 20px;
 	margin-top: -124px;
 	background-color:white;
 
-	ul, li
-	{
+	ul,
+	li {
 		display: block;
 		list-style:none;
 		padding:0;
@@ -18,185 +16,187 @@ ul.uams-mobile-menu
 	}
 
 	li.pagenav,
-	>div
-	{
-			a, span
-			{
-				// font-family: @font-family-headline;
-				display: block;
-			    font-size: floor(@font-size-base * 0.95);
-				padding: 10px 10px 10px 20px;
+	> div {
+		a,
+		span {
+			// font-family: @font-family-headline;
+			display: block;
+			font-size: floor(@font-size-base * 0.95);
+			padding: 10px 10px 10px 20px;
 
-				&.homelink
-				{
-					display:none;
-					color:@red;
-					font-size:floor(@font-size-base * 1.111);
+			&.homelink {
+				display:none;
+				color:@red;
+				font-size:floor(@font-size-base * 1.111);
+			}
+		}
+
+		ul {
+			line-height: 1.3;
+			font-size: ceil(@font-size-base * 1.111);
+
+			li.current_page_item,
+			li.current_page_parent {
+				background-color: @red;
+
+				& > a,
+				& > span {
+					font-weight: bold;
+					padding-left: 19px;
+					padding-top: 16px;
+					padding-bottom: 16px;
+				}
+
+				a,
+				span {
+					color:white;
+					border-bottom: none;
+					border-left: 10px solid @700grey;
+				}
+
+				&.current_page_ancestor {
+					position: relative;
+
+					& > a {
+						padding-right: 60px;
+
+						&:hover,
+						&:focus {
+							color: @50grey;
+						}
+
+						&:after {
+							content: "";
+							background: url(assets/svg/uams-sprite.svg) no-repeat -224px -478px;
+							display: inline-block;
+							height: 52px;
+							width: 44px;
+							margin-left: 7px;
+							margin-top: -26px;
+							position: absolute;
+							right: 0;
+							top: 50%;
+							background-color: @900grey;
+						}
+					}
+
+					a,
+					span {
+						border-left: none;
+						position: relative;
+					}
+				}
+
+				li.page_item_has_children {
+					ul {
+						display:none;
+					}
+				}
+
+				li.page_item_has_children.current_page_item {
+					ul {
+						display:block;
+					}
 				}
 			}
 
-			ul
-			{
-
-				line-height: 1.3;
-    			font-size: ceil(@font-size-base * 1.111);
-
-				li.current_page_item, li.current_page_parent
-				{
-					background-color: @red;
-					& > a,
-					& > span {
-						font-weight: bold;
-						padding-left: 19px;
-						padding-top: 16px;
-						padding-bottom: 16px;
-					}
-                    a,
-					span {
-						color:white;
-						border-bottom: none;
-						border-left: 10px solid @700grey;
-					}
-					&.current_page_ancestor {
-						position: relative;
-						& > a {
-							padding-right: 60px;
-                            &:hover,
-                            &:focus{
-                                color: @50grey;
-                            }
-							&:after {
-								content: "";
-								background: url(assets/svg/uams-sprite.svg) no-repeat -224px -478px;
-								display: inline-block;
-								height: 52px;
-								width: 44px;
-								margin-left: 7px;
-								margin-top: -26px;
-								position: absolute;
-								right: 0;
-								top: 50%;
-								background-color: @900grey;
-							}
-						}
-						a,
-                        span {
-							border-left: none;
-							position: relative;
-
-						}
-					}
-
-					li.page_item_has_children ul {
-						display:none;
-					}
-
-					li.page_item_has_children.current_page_item ul {
-						display:block;
-					}
-
+			li {
+				a	{
+					color: @red;
+					border-bottom: thin solid @200grey;
 				}
-
-				li
-				{
-					a	{
-						color: @red;
-						border-bottom: thin solid @200grey;
-					}
-					&.current_page_item ul.children, &.current_page_ancestor ul.children
-					{
+				&.current_page_item,
+				&.current_page_ancestor {
+					ul.children {
 						display:block;
 						font-size: @font-size-base;
 						background-color:white;
 
-						li
-						{
+						li {
 							background-color:@200grey;
 							border-bottom: 1px solid #fff;
+	
 							a,
-                            span
-							{
+							span {
 								color:@darkgray;
 								padding: 10px 30px 10px 20px;
 								border-left: 10px solid @200grey;
+	
 								&:hover,
-                                &:focus {
+								&:focus {
 									background-color: @200grey;
 									border-color: @500grey;
 								}
+	
 								&:visited {
 									color: @red;
 								}
 							}
-
 						}
-
-						li.current_page_item
-						{
+	
+						li.current_page_item {
 							// background-color:white;
+	
 							ul.children {
 								li {
 									border-bottom: 1px solid #E0E0E0;
 								}
+	
 								li:last-child {
 									border-bottom: none;
 								}
+	
 								a {
 									background-color: white;
 									color: @darkgray;
 									border-left: 10px solid white;
 									padding-left: 25px;
+	
 									&:before {
 										content: "- ";
 									}
+	
 									&:hover,
-	                                &:focus {
+									&:focus {
 										border-color: @500grey;
 									}
+	
 									&:visited {
 										color: @red;
 									}
 								}
 							}
-							span
-							{
+							span {
 								// background-color:#757575;
 								border-left: 10px solid @700grey;
 								padding-left: 20px;
 								background-color: @200grey;
+								// color:white;
+								border-bottom: none;
+	
 								a
 								{
 									color:white;
 									border-bottom: none;
 								}
-								// color:white;
-								border-bottom: none;
 							}
 						}
-
-
-					}
-
-
-				}
-
-				li:last-child
-				{
-					a
-					{
-						// color:@red;
-						border-bottom: none;
 					}
 				}
-
 			}
 
+			li:last-child {
+				a {
+					// color:@red;
+					border-bottom: none;
+				}
+			}
 		}
+	}
 
-		ul.children {
-			display:none;
-		}
-
+	ul.children {
+		display:none;
+	}
 }
 
 // Sidebar widget titles
@@ -209,6 +209,7 @@ ul.uams-mobile-menu
 		text-transform: uppercase;
 		position: relative;
 		padding-bottom: 20px;
+
 		&:after,
 		&:before {
 			position: absolute;
@@ -217,10 +218,12 @@ ul.uams-mobile-menu
 			content: "";
 			height: 4px;
 		}
+
 		&:before {
 			width: 100px;
 			background-color: @700grey;
 		}
+
 		&:after {
 			width: 40px;
 			.skew(-25deg,0);
@@ -230,29 +233,37 @@ ul.uams-mobile-menu
 			height: 8px;
 		}
 	}
+
 	p {
 		color: @font-color-base;
 	}
 }
 
-.page-template-no-title ul.uams-sidebar-menu,
-.page-template-blank ul.uams-sidebar-menu {
-	margin-top: 0;
+.page-template-no-title,
+.page-template-blanku {
+	ul.uams-sidebar-menu {
+		margin-top: 0;
+	}
 }
 
-.page-template-no-hero ul.uams-sidebar-menu {
-	margin-top: -56px;
+.page-template-no-hero {
+	ul.uams-sidebar-menu {
+		margin-top: -56px;
+	}
 }
 
-
-body.home .uams-sidebar-menu {
-	display: none;
+body.home {
+	.uams-sidebar-menu {
+		display: none;
+	}
 }
-body.page-template-home ul.uams-sidebar-menu,
-body.page-template-home ul.uams-mobile-menu,
-body.action-bar ul.uams-sidebar-menu,
-body.action-bar ul.uams-mobile-menu {
-	margin-top: -42px; //Home template fix
+
+body.page-template-home,
+body.action-bar {
+	ul.uams-sidebar-menu,
+	ul.uams-mobile-menu {
+		margin-top: -42px; //Home template fix
+	}
 }
 
 /* Medium Devices, Desktops */
@@ -268,5 +279,9 @@ body.action-bar ul.uams-mobile-menu {
 	.uams-sidebar {
 		padding-top: 40px;
 	}
-	.blank .uams-sidebar { padding-top: 0; }
+	.blank {
+		.uams-sidebar {
+			padding-top: 0;
+		}
+	}
 }

--- a/less/uams.sidebar.less
+++ b/less/uams.sidebar.less
@@ -204,7 +204,7 @@ ul.uams-mobile-menu
 .uams-sidebar {
 	.widgettitle {
         clear:left;
-		font-weight: @heavy;
+		font-weight: @heading;
 		font-size: floor(@font-size-base * 1.2);
 		text-transform: uppercase;
 		position: relative;

--- a/less/uams.sidebar.less
+++ b/less/uams.sidebar.less
@@ -41,7 +41,7 @@ ul.uams-mobile-menu {
 
 				& > a,
 				& > span {
-					font-weight: bold;
+					font-weight: @bold;
 					padding-left: 19px;
 					padding-top: 16px;
 					padding-bottom: 16px;

--- a/less/uams.sidebar.less
+++ b/less/uams.sidebar.less
@@ -204,7 +204,7 @@ ul.uams-mobile-menu
 .uams-sidebar {
 	.widgettitle {
         clear:left;
-		font-weight: @ultra;
+		font-weight: @heavy;
 		font-size: floor(@font-size-base * 1.2);
 		text-transform: uppercase;
 		position: relative;

--- a/less/uams.slideshow.less
+++ b/less/uams.slideshow.less
@@ -40,7 +40,7 @@ div.uams-slideshow
 
 
 
-      h3 {
+      h3, .h3 {
         color      :white;
         float      :none;
         margin     :10px 60px 0 0;
@@ -195,7 +195,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
           padding: 10px 30px;
           bottom: -300px;
           .transition(bottom ease-in-out 0.1s);
-          h3 {
+          h3, .h3 {
             font-size: 18px;
           }
           p {
@@ -461,16 +461,20 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
       bottom: 50px;
     }
   }
-  div.uams-slideshow>div.slide div h3 {
-    margin: 10px 0 0 0;
-  }
-  div.uams-slideshow > div.slide div {
-    padding: 20px 20px 55px;
-    opacity: 1;
-    width: 100%;
-    bottom: 0;
-    p {
-      width: 100%;
+  div.uams-slideshow {
+    > div.slide {
+      div {
+        padding: 20px 20px 55px;
+        opacity: 1;
+        width: 100%;
+        bottom: 0;
+        p {
+          width: 100%;
+        }
+        h3, .h3 {
+          margin: 10px 0 0 0;
+        }
+      }
     }
   }
 

--- a/less/uams.slideshow.less
+++ b/less/uams.slideshow.less
@@ -1,6 +1,4 @@
-div.uams-slideshow
-{
-
+div.uams-slideshow {
   position :relative;
   overflow: hidden;
   width: 100%;
@@ -9,7 +7,6 @@ div.uams-slideshow
   z-index: 0;
 
   > div.slide {
-
     position:absolute;
     right: 0;
     left: 0;
@@ -30,20 +27,19 @@ div.uams-slideshow
     }
 
     div {
-        position         :absolute;
-        left             :0;
-        bottom           :5%;
-        background-color :@red;
-        opacity          :.9;
-        padding          :12px 0 10px 40px;
-        width            :77.5%;
-
-
+      position:absolute;
+      left: 0;
+      bottom: 5%;
+      background-color: @red;
+      opacity: .9;
+      padding: 12px 0 10px 40px;
+      width: 77.5%;
 
       h3, .h3 {
-        color      :white;
-        float      :none;
-        margin     :10px 60px 0 0;
+        color: white;
+        float: none;
+        margin: 10px 60px 0 0;
+
         a {
           color: white;
           border: none;
@@ -58,13 +54,10 @@ div.uams-slideshow
         line-height: 20px;
         padding-top: 7px;
       }
-
     }
-
   }
 
-  .uams-slideshow-controls
-  {
+  .uams-slideshow-controls {
     color: @gray;
     line-height:60px;
     font-size:30px;
@@ -74,26 +67,28 @@ div.uams-slideshow
     height:80px;
     width: 45px;
     bottom: 36px;
-    &.next:after,
-    &.previous:after {
-      background: url(assets/svg/uams-sprite.svg) no-repeat -698px -97px;
-      content: "";
-      width: 81px;
-      height: 44px;
-      position: absolute;
-      top: 21px;
-      left: 15px;
-      background-size: 1700px;
+
+    &.next,
+    &.previous {
+      &:after {
+        background: url(assets/svg/uams-sprite.svg) no-repeat -698px -97px;
+        content: "";
+        width: 81px;
+        height: 44px;
+        position: absolute;
+        top: 21px;
+        left: 15px;
+        background-size: 1700px;
+      }
     }
 
     &.next {
       z-index:101;
       left: 77.5%;
       .box-shadow(-1px 0px 5px 0 rgba(0, 0, 0, .4));
-      &:after {
-
-      }
-      // background: white url('@{local-image-path}/slideshow-arrow-right.png') center no-repeat;
+      //background: white url('@{local-image-path}/slideshow-arrow-right.png') center no-repeat;
+      //&:after {
+      //}
     }
 
     &.previous {
@@ -107,23 +102,17 @@ div.uams-slideshow
 
   }
 
-  &.last-previous
-  {
-
+  &.last-previous {
     .next {
       z-index:100;
     }
 
-    .previous
-    {
+    .previous {
       opacity:0.2;
     }
-
   }
 
-  &.last-next
-  {
-
+  &.last-next {
     .next {
       opacity:0.2;
     }
@@ -131,19 +120,15 @@ div.uams-slideshow
     .previous {
       z-index:100;
     }
-
   }
 
   // For the simple photo slider
 
   &.photo-slider {
-
-
       height: 510px;
       padding-bottom: 51px;
 
       // For class switching on dots
-
       .dotSlide {
         z-index: 99 !important;
         left: 0 !important;
@@ -169,35 +154,40 @@ div.uams-slideshow
         right: 0;
         width: 250px;
         z-index: 19;
-background: -moz-linear-gradient(-45deg,  rgba(255,255,255,0) 0%, rgba(128,128,128,0) 50%, rgba(0,0,0,1) 100%); /* FF3.6+ */
-background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(50%,rgba(128,128,128,0)), color-stop(100%,rgba(0,0,0,1))); /* Chrome,Safari4+ */
-background: -webkit-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* Chrome10+,Safari5.1+ */
-background: -o-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* Opera 11.10+ */
-background: -ms-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* IE10+ */
-background: linear-gradient(135deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* W3C */
-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#000000',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
-
+        background: -moz-linear-gradient(-45deg,  rgba(255,255,255,0) 0%, rgba(128,128,128,0) 50%, rgba(0,0,0,1) 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(50%,rgba(128,128,128,0)), color-stop(100%,rgba(0,0,0,1))); /* Chrome,Safari4+ */
+        background: -webkit-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* Chrome10+,Safari5.1+ */
+        background: -o-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* Opera 11.10+ */
+        background: -ms-linear-gradient(-45deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* IE10+ */
+        background: linear-gradient(135deg,  rgba(255,255,255,0) 0%,rgba(128,128,128,0) 50%,rgba(0,0,0,1) 100%); /* W3C */
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#000000',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
       }
-      & > div.slide {
+
+      > div.slide {
         overflow: hidden;
         height: 90%;
+
         &.no-text div {
           display: none;
         }
+
         &:hover {
           div {
             bottom: 0;
           }
         }
+
         div {
           background-color: rgba(0, 0, 0, 0.7);
           width: 100%;
           padding: 10px 30px;
           bottom: -300px;
           .transition(bottom ease-in-out 0.1s);
+
           h3, .h3 {
             font-size: 18px;
           }
+
           p {
             font-size: 15px;
           }
@@ -205,7 +195,6 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
       }
 
       // Adds a litte 'i' for hover
-
       .has-text:after {
         font-family: @font-family-headline;
         font-weight: @extrabold;
@@ -231,39 +220,48 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
         background-color: transparent;
         bottom: 10%;
         width: 75px;
+
         &.next,
         &.previous {
           .box-shadow(none);
+
           &:hover,
           &:focus {
             border-bottom: none;
           }
         }
+
         &.previous {
           left: auto;
           right: 90px;
+
           &:hover,
           &:focus {
             right: 95px;
           }
         }
+
         &.next {
           left: auto;
           right: 5px;
+
           &:hover,
           &:focus {
             right: 0;
           }
         }
-        &.next:after,
-        &.previous:after {
-          width: 46px;
-          left: 10px;
-          background: url(assets/svg/uams-sprite.svg) no-repeat -55px -545px rgba(0, 0, 0, 0);
-          background-size: 970px;
-        }
 
+        &.next,
+        &.previous {
+          &:after {
+            width: 46px;
+            left: 10px;
+            background: url(assets/svg/uams-sprite.svg) no-repeat -55px -545px rgba(0, 0, 0, 0);
+            background-size: 970px;
+          }
+        }
     }
+
     .slider-dots {
       position: relative;
       bottom: 0;
@@ -271,6 +269,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
       text-align: center;
       margin-top: 465px;
       padding: 0;
+
       li {
         list-style: none;
         display: inline-block;
@@ -279,6 +278,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
         margin: 0 3px;
         background-color: #C8C8C8;
         cursor: pointer;
+
         &:hover,
         &.select-dot {
           background-color: #484848;
@@ -299,14 +299,13 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
       z-index: 50;
       .transition(scale linear .1s);
       border-bottom: none;
+
       &:hover {
         .scale(1.2);
         transform-origin: center center;
       }
     }
-
   }
-
 }
 
 .activeFullscreen div.uams-slideshow.photo-slider {
@@ -317,6 +316,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
   width: 90%;
   height: auto;
   z-index: 100;
+
   &:after {
     position: fixed;
     top: 0;
@@ -328,28 +328,28 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
     background-color: rgba(0,0,0,.8);
     z-index: -1;
   }
+
   a.fullscreen {
     background-position: 0px -93px;
   }
-  & > div.slide {
+
+  > div.slide {
     background-color: black;
   }
 
-
   // For flashing bug
-  &.last-previous
-  {
-    .previous
-    {
+  &.last-previous {
+    .previous {
       opacity:1;
     }
   }
-  &.last-next
-  {
+
+  &.last-next {
     .next {
       opacity:1;
     }
   }
+
   .slider-dots {
     position: absolute;
     bottom: 20px;
@@ -357,7 +357,6 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
     margin-top: 0;
     padding: 0;
   }
-
 }
 // Accounts for template with no sidebar
 
@@ -365,24 +364,30 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
   .page-template-no-sidebar {
     div.uams-slideshow {
       height: 550px;
+
       .uams-slideshow-controls.next {
         right: 212px;
       }
+
       .uams-slideshow-controls.previous {
         right: 257px;
       }
+
       &.photo-slider {
         height: 690px;
         .uams-slideshow-controls.next {
           right: 2px;
         }
+
         .uams-slideshow-controls.previous {
           right: 107px;
         }
+
         .slider-dots {
           margin-top: 645px;
         }
-        &  > div.slide {
+
+        > div.slide {
           overflow: hidden;
           height: 92.5%;
         }
@@ -391,21 +396,19 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
   }
 }
 
-
-
-
-
-
 @media only screen and (max-width : 1200px) {
   div.uams-slideshow.photo-slider .slider-dots {
     margin-top: 390px;
   }
+
   div.uams-slideshow.photo-slider {
     height: 420px;
     padding-bottom: 60px;
+
     &:after {
       bottom: 42px;
     }
+
     .has-text:after,
     &> div.slide div {
      display: none;
@@ -413,33 +416,38 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
   }
 }
 
-
 @media only screen and (max-width : 767px) {
-
   div.uams-slideshow .uams-slideshow-controls {
     height:45px;
     bottom: 0;
+
     &.next {
       right: 0;
       left: auto;
     }
+
     &.previous {
       right: 45px;
       left: auto;
       margin-left: 0;
     }
+
     &.next:after,
     &.previous:after {
       top: 3px;
     }
   }
+
   div.uams-slideshow.photo-slider {
     height: 420px;
     padding-bottom: 0;
+
     .uams-slideshow-controls {
       bottom: 55px;
+
       &.previous {
         right: 60px;
+
         &:hover,
         &:focus {
           right: 65px;
@@ -447,20 +455,24 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
       }
       &.next {
         right: -18px;
+
         &:hover,
         &:focus {
           right: -22px;
         }
       }
     }
+
     &:before {
       bottom: 5%;
       right: 40px;
     }
+
     &:after {
       bottom: 50px;
     }
   }
+
   div.uams-slideshow {
     > div.slide {
       div {
@@ -468,14 +480,15 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
         opacity: 1;
         width: 100%;
         bottom: 0;
+
         p {
           width: 100%;
         }
+
         h3, .h3 {
           margin: 10px 0 0 0;
         }
       }
     }
   }
-
 }

--- a/less/uams.slideshow.less
+++ b/less/uams.slideshow.less
@@ -208,7 +208,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', e
 
       .has-text:after {
         font-family: @font-family-headline;
-        font-weight: @bold;
+        font-weight: @extrabold;
         content: "i";
         font-size: 13px;
         text-align: center;

--- a/less/uams.tabs.less
+++ b/less/uams.tabs.less
@@ -6,7 +6,7 @@
 
 
 .uams-tabs {
-    h3 {
+    h3, .h3 {
         background-color: @300grey;
         color: @800grey;
         padding: 15px 15px 15px 15px;
@@ -17,15 +17,15 @@
         cursor: pointer;
         &.active:after {
             background-position: -383px -23px;
-        }
-    }
-    h3:after {
-        content: " ";
-        float: right;
-        display: block;
-        width: 30px;
-        height: 25px;
-        background: url(assets/svg/uams-sprite.svg) no-repeat -383px 2px rgba(255, 255, 255, 0);
+		}
+		&:after {
+			content: " ";
+			float: right;
+			display: block;
+			width: 30px;
+			height: 25px;
+			background: url(assets/svg/uams-sprite.svg) no-repeat -383px 2px rgba(255, 255, 255, 0);
+		}
     }
     div {
         height: 0px;

--- a/less/uams.templates.less
+++ b/less/uams.templates.less
@@ -7,8 +7,10 @@ body.page-template-big-hero
   }
 
 }
-h1.post-link-title {
-	margin-left: 1.2em;
+h1, .h1 {
+  &.post-link-title {
+    margin-left: 1.2em;
+  }
 }
 .post-link-icon {
   	color: #e0e0e0;

--- a/less/uams.thinstrip.less
+++ b/less/uams.thinstrip.less
@@ -81,7 +81,7 @@
 		margin: 0;
 		position: relative;
 		z-index: 1;
-		font-weight: @medium;
+		font-weight: @semibold;
 		padding: 0;
 
 		li {
@@ -94,7 +94,7 @@
 				font-family: @font-family-headline;
 				color: @red;
 				font-size: 17px;
-				font-weight: @medium;
+				font-weight: @semibold;
 				position: relative;
 				float: right;
 				padding: 8px 25px 10px 0;
@@ -122,7 +122,7 @@
         vertical-align: top;
         font-family: @font-family-headline;
         font-size: 17px;
-        font-weight: @medium;
+        font-weight: @semibold;
         position: relative;
         z-index: 1;
         &.uams-search {

--- a/less/uams.thinstrip.less
+++ b/less/uams.thinstrip.less
@@ -229,11 +229,11 @@
 	position: absolute;
 	top: 22px;
 	height: 85px;
-	& h1 {
+	h1, .h1 {
 		margin: 0;
 		padding: 0;
 		font-size: 35px;
-		& a {
+		a {
 			color: @red;
 			&.long-title {
 			font-size: 32px;
@@ -325,8 +325,7 @@
 			background-size: 640px;
       .transition(all 0s);
       &:hover,
-      &:focus,
-      {
+      &:focus {
         background-size: 640px;
       }
 		}
@@ -394,9 +393,9 @@
     #site-title {
 	    max-width: 90%;
 	    top: 62px;
-	    & h1 {
+	    h1, .h1 {
 		    font-size: 30px;
-		    & a {
+		    a {
 			    &.long-title {
 				font-size: 26px;
 				}
@@ -422,8 +421,7 @@
 				background-size: 640px;
 				.transition(all 0s);
 				&:hover,
-				&:focus,
-				{
+				&:focus {
 		        	background-size: 640px;
 		      	}
 		    }
@@ -461,8 +459,7 @@
 			height: 48px;
 			background-size: auto;
 			&:hover,
-		    &:focus,
-		    {
+		    &:focus {
 		        background-size: auto;
 		    }
 		}
@@ -479,8 +476,7 @@
 			height: 45px;
 			background-size: 780px;
 			&:hover,
-		    &:focus,
-		    {
+		    &:focus {
 		        background-size: 780px;
 		    }
 		}

--- a/less/uams.thinstrip.less
+++ b/less/uams.thinstrip.less
@@ -81,7 +81,7 @@
 		margin: 0;
 		position: relative;
 		z-index: 1;
-		font-weight: @semibold;
+		font-weight: @heading;
 		padding: 0;
 
 		li {
@@ -94,7 +94,7 @@
 				font-family: @font-family-headline;
 				color: @red;
 				font-size: 17px;
-				font-weight: @semibold;
+				font-weight: @heading;
 				position: relative;
 				float: right;
 				padding: 8px 25px 10px 0;
@@ -122,7 +122,7 @@
         vertical-align: top;
         font-family: @font-family-headline;
         font-size: 17px;
-        font-weight: @semibold;
+        font-weight: @heading;
         position: relative;
         z-index: 1;
         &.uams-search {

--- a/less/uams.thinstrip.less
+++ b/less/uams.thinstrip.less
@@ -233,6 +233,7 @@
 		margin: 0;
 		padding: 0;
 		font-size: 35px;
+		font-weight: @extrabold;
 		a {
 			color: @red;
 			&.long-title {

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -93,7 +93,9 @@
 @bold:	 					700;
 @semibold: 					600;
 @regular:					400;
-@body:						300;
+@light:						300;
+
+@body:						@light;
 
 
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -99,6 +99,7 @@
 @thin:			        	100;
 
 @body:						@light;
+@heading:                   @medium;
 
 
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -91,7 +91,7 @@
 @ultra: 		 			900;
 @extrabold:		 			800;
 @bold:	 					700;
-@medium: 					600;
+@semibold: 					600;
 @light:						400;
 @body:						300;
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -92,8 +92,11 @@
 @extrabold:		 			800;
 @bold:	 					700;
 @semibold: 					600;
+@medium: 					500;
 @regular:					400;
 @light:						300;
+@extralight:				200;
+@thin:			        	100;
 
 @body:						@light;
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -92,7 +92,7 @@
 @extrabold:		 			800;
 @bold:	 					700;
 @semibold: 					600;
-@light:						400;
+@regular:					400;
 @body:						300;
 
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -104,7 +104,7 @@
 
 // Legacy weights
 @ultra-font-weight: 		@heavy;
-@headings-font-weight:		@extrabold;
+@headings-font-weight:		@medium;
 @body-font-weight:			@body;
 
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -143,3 +143,8 @@
 @btn-success-bg:				 @green-darker; // a11y & brand
 
 @btn-info-bg:					 @blue; // a11y & brand
+
+//** Hero shadows
+
+@hero-shadow-dark:  0.5px 0.5px 3px rgba(0, 0, 0, 0.5);
+@hero-shadow-light: 0.5px 0.5px 3px rgba(225, 225, 225, 0.5);

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -87,13 +87,6 @@
 @uni-sans:      				"uni_sans_thin-webfont";
 
 
-
-// Legacy weights
-@ultra-font-weight: 		900;
-@headings-font-weight:		800;
-@body-font-weight:			300;
-
-
 // Readjusted for simplicity (the old ones still work)
 @ultra: 		 			900;
 @bold:		 				800;
@@ -101,6 +94,13 @@
 @medium: 					600;
 @light:						400;
 @body:						300;
+
+
+
+// Legacy weights
+@ultra-font-weight: 		@ultra;
+@headings-font-weight:		@bold;
+@body-font-weight:			@body;
 
 
 // Iconography

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -88,7 +88,7 @@
 
 
 // Readjusted for simplicity (the old ones still work)
-@ultra: 		 			900;
+@heavy: 		 			900;
 @extrabold:		 			800;
 @bold:	 					700;
 @semibold: 					600;
@@ -103,7 +103,7 @@
 
 
 // Legacy weights
-@ultra-font-weight: 		@ultra;
+@ultra-font-weight: 		@heavy;
 @headings-font-weight:		@extrabold;
 @body-font-weight:			@body;
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -89,7 +89,7 @@
 
 // Readjusted for simplicity (the old ones still work)
 @ultra: 		 			900;
-@bold:		 				800;
+@extrabold:		 			800;
 @heavy:	 					700;
 @medium: 					600;
 @light:						400;
@@ -99,7 +99,7 @@
 
 // Legacy weights
 @ultra-font-weight: 		@ultra;
-@headings-font-weight:		@bold;
+@headings-font-weight:		@extrabold;
 @body-font-weight:			@body;
 
 

--- a/less/uams.variables.less
+++ b/less/uams.variables.less
@@ -90,7 +90,7 @@
 // Readjusted for simplicity (the old ones still work)
 @ultra: 		 			900;
 @extrabold:		 			800;
-@heavy:	 					700;
+@bold:	 					700;
 @medium: 					600;
 @light:						400;
 @body:						300;

--- a/less/uams.youtube.less
+++ b/less/uams.youtube.less
@@ -91,7 +91,7 @@
             color: @red;
             text-transform: uppercase;
             font-size: 11px;
-            font-weight: @bold;
+            font-weight: @extrabold;
 	    }
         &.vid-active div {
             opacity: 1;
@@ -108,7 +108,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            font-weight: @bold;
+            font-weight: @extrabold;
             color: #FFF;
             padding: 5px 10px 5px 10px;
             overflow: hidden;

--- a/less/uams.youtube.less
+++ b/less/uams.youtube.less
@@ -5,28 +5,32 @@
 
 
 .tube-wrapper {
-     position: relative;
-     padding-bottom: 56.25%;
-     padding-top: 30px; height: 0; overflow: hidden;
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 30px; height: 0; overflow: hidden;
+
+    iframe,
+    object,
+    embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
 }
-.tube-wrapper iframe,
-.tube-wrapper object,
-.tube-wrapper embed {
-	 position: absolute;
-	 top: 0;
-	 left: 0;
-	 width: 100%;
-	 height: 100%;
-}
+
 .nc-video-player {
     clear: both;
     width: 100%;
     background-color: #FFF;
     position: relative;
+
     &.playlist {
         box-shadow: 1px 1px 7px #E0E0E0;
         margin-bottom: 35px;
         margin-top: 30px;
+
         &:after {
             content: " ";
             position: absolute;
@@ -37,18 +41,21 @@
             background: url("assets/images/youtube-player/video-overflow.png") 0 0 no-repeat;
         }
     }
+
     iframe {
     	max-width: none !important;
     	padding: 0;
     	margin: 0;
     }
 }
+
 .playBtn {
     left: 43px;
     position: absolute;
     top: 31px;
     z-index: 0;
-    border: none; }
+    border: none;
+}
 
 .vidSmall {
     height: 130px;
@@ -70,9 +77,11 @@
         font-size: 12px;
         color: white;
     }
+
     .title {
         margin: 3px 3px 0 0 ;
     }
+
     button {
         border: none;
         display: block;
@@ -81,27 +90,37 @@
         position: relative;
         padding: 0;
         width: 120px;
-        &.vid-active:after {
-            content: "Now Playing";
-            padding: 0px 7px;
-            background-color: #FFF;
-            position: absolute;
-            bottom: -3px;
-            left: 10px;
-            color: @red;
-            text-transform: uppercase;
-            font-size: 11px;
-            font-weight: @extrabold;
-	    }
-        &.vid-active div {
-            opacity: 1;
+
+        &.vid-active {
+            &:after {
+                content: "Now Playing";
+                padding: 0px 7px;
+                background-color: #FFF;
+                position: absolute;
+                bottom: -3px;
+                left: 10px;
+                color: @red;
+                text-transform: uppercase;
+                font-size: 11px;
+                font-weight: @extrabold;
+            }
+
+            div {
+                opacity: 1;
+            }
         }
-        &:hover div, &:focus div {
-            opacity: 1;
+        
+        &:hover,
+        &:focus {
+            div {
+                opacity: 1;
+            }
+
+            .playBtn {
+                display: none;
+            }
         }
-        &:hover .playBtn, &:focus .playBtn {
-            display: none;
-        }
+
         div {
             position: absolute;
             top: 0;
@@ -120,14 +139,17 @@
             -webkit-transition: opacity .25s ease-in-out;
         }
     }
+
     img {
         margin: 0;
         padding: 0;
     }
+
 	ul {
 		margin: 0px;
         padding: 0px;
-	}
+    }
+    
     li {
     	float: left;
     	width: 120px;
@@ -137,6 +159,7 @@
         list-style: none;
         cursor: pointer;
     }
+
     .duration {
     	color: @400grey ;
     	background: url('assets/images/youtube-player/play-sm.png') right 2px no-repeat transparent;
@@ -145,6 +168,7 @@
     	float: left;
     	margin-top: 3px;
     }
+
     .viewport {
     	height: 95px;
     	overflow: hidden;
@@ -152,16 +176,19 @@
     	width: 96%;
     	margin: 0 2%;
     }
+
     .overview {
     	list-style: none;
     	position: absolute;
     	left: 0;
     	top: 0;
     }
+
     .thumb .end,
     .thumb {
     	background-color: @600grey;
     }
+
     .scrollbar {
    		display: none;
    		float: right;
@@ -171,6 +198,7 @@
    		left: 2%;
    		height: 7px;
     }
+
     .track {
         background-color: @100grey;
         height: 100%;
@@ -178,6 +206,7 @@
         position: relative;
         padding: 0 1px;
     }
+
     .thumb {
         height: 7px;
         width: 8px;
@@ -185,11 +214,15 @@
         overflow: hidden;
         position: absolute;
         bottom: 0;
+
         .end {
         	overflow: hidden;
         	height: 5px;
         	width: 8px;
         }
     }
-    .disable { display: none }
+
+    .disable {
+        display: none
+    }
 }

--- a/less/widgets/cards.less
+++ b/less/widgets/cards.less
@@ -4,7 +4,7 @@
 	margin-top: 20px;
 	h3, .h3 {
 		font-family: @headings-font-family;
-  		font-weight: @heavy;
+  		//font-weight: @heavy;
   		line-height: @headings-line-height;
   		text-transform: uppercase;
   	}

--- a/less/widgets/cards.less
+++ b/less/widgets/cards.less
@@ -2,7 +2,7 @@
 
 .cards-widget {
 	margin-top: 20px;
-	h3 {
+	h3, .h3 {
 		font-family: @headings-font-family;
   		font-weight: @ultra;
   		line-height: @headings-line-height;
@@ -31,7 +31,7 @@
 		      	}
 		    }
 		}
-		h3 {
+		h3, .h3 {
   			font-size: 25px;
   			color: @red;
   			a {
@@ -54,7 +54,7 @@
 		}
 	}
 	.styled-card {
-		h3 {
+		h3, .h3 {
   			font-size: 30px;
   			a {
   				color: white;
@@ -84,7 +84,7 @@
 		& > span {
 			display: block;
 		}
-		h3 {
+		h3, .h3 {
     		font-size: 18px;
     		position: relative;
     		background-color:  @red;

--- a/less/widgets/cards.less
+++ b/less/widgets/cards.less
@@ -4,7 +4,7 @@
 	margin-top: 20px;
 	h3, .h3 {
 		font-family: @headings-font-family;
-  		font-weight: @ultra;
+  		font-weight: @heavy;
   		line-height: @headings-line-height;
   		text-transform: uppercase;
   	}

--- a/less/widgets/contact.less
+++ b/less/widgets/contact.less
@@ -8,7 +8,7 @@
 	}
 	h3, .h3 {
 		font-size: 19px;
-  		font-weight: @ultra;
+  		font-weight: @heavy;
  		margin-top: 35px;
  		margin-bottom: 5px;
 	}

--- a/less/widgets/contact.less
+++ b/less/widgets/contact.less
@@ -6,7 +6,7 @@
 		margin: 0;
 		font-size: 16px;
 	}
-	h3 {
+	h3, .h3 {
 		font-size: 19px;
   		font-weight: @ultra;
  		margin-top: 35px;

--- a/less/widgets/recent-entries.less
+++ b/less/widgets/recent-entries.less
@@ -8,21 +8,26 @@
 	ul {
 		padding: 0;
 	}
+
 	li {
 		clear: both;
 		padding-top: 5px;
 		list-style: none;
 		margin: 0;
+
 		&:last-child {
 			p:after {
 				display: none;
 			}
 		}
 	}
-	p, span {
+
+	p,
+	span {
 		margin: 0;
 		position: relative;
 		padding-bottom: 20px;
+
 		&:after {
 			position: absolute;
 			bottom: 10px;
@@ -33,6 +38,7 @@
 			background-color: @gray;
 		}
 	}
+
 	img {
 		.border-radius(100%);
 		overflow: hidden;
@@ -42,9 +48,11 @@
 		margin: 5px 25px 15px 0px;
 		float: left;
 	}
+
 	a.widget-thumbnail {
 
 	}
+
 	a.widget-link {
 		font-family: @font-family-headline;
 		color: @red;
@@ -53,48 +61,54 @@
 		line-height: 1.4;
 		overflow: hidden;
 		display: block;
+		
+		&:hover {
+			color: #909090;
+			border-bottom: none;
+		}
+
 		span {
 			font-size: 17px;
 			color: #818181;
 			margin-top: 3px;
 			font-weight: 400;
 		}
-		&:hover {
-			color: #909090;
-			border-bottom: none;
-		}
 	}
+
 	.more {
 		margin: 10px 0 0 0;
 	}
+
 	small {
 		font-family: @font-family-headline;
 		font-size: floor(@font-size-base * .8);
 		font-weight: 400;
 	}
+
 	span {
 		display: block;
 		overflow: hidden;
 	}
+
 	svg {
 		margin-left: 10px;
 	}
 }
+
 ul.shortcode-blogroll-mini {
 	padding-left: 0;
 }
 
 // Fixes UL padding of shortcode
-
 .uams-content .uams-widget-rss {
 	padding: 0;
 }
 
 // Necessary for sidebar, and hides blank span
-
 .uams-sidebar .uams-widget-rss.widget {
-    // padding: 10px 0 0 40px;
-    & > span:nth-child(1) {
+	// padding: 10px 0 0 40px;
+	
+    > span:nth-child(1) {
     	display: none;
 	}
 }

--- a/less/widgets/recent-entries.less
+++ b/less/widgets/recent-entries.less
@@ -49,7 +49,7 @@
 		font-family: @font-family-headline;
 		color: @red;
 		font-size: floor(@font-size-base * .95);
-		font-weight: @bold;
+		font-weight: @extrabold;
 		line-height: 1.4;
 		overflow: hidden;
 		display: block;


### PR DESCRIPTION
- Added .h[1-6] classes where there were none, beside the h[1-6] text elements, mirroring [Bootstrap's helper classes](https://getbootstrap.com/docs/3.3/css/#type-headings), in case we need to maintain proper heading outline but want the appearance of a different heading level.
- Added and rearranged some font-weight variables.
- Assigned the new variables to the various text elements.
- Changed font-weight variables on various text elements.
- Added some new shadow value variables.
- Assigned those new shadow variables to text elements within the heroes.
- Adjusted hero next text styles.
- Added styles for dt element.
- General code refactoring ... nesting rule-sets, adjusting tabs and spaces between rule-sets.